### PR TITLE
Support response headers

### DIFF
--- a/features/support/support.js
+++ b/features/support/support.js
@@ -78,7 +78,7 @@ When(
 );
 
 When(/extracting the object at index ([0-9]*)/, (index) => {
-  apiResponse = apiResponse[parseInt(index)];
+  apiResponse.data = apiResponse.data[parseInt(index)];
 });
 
 When(
@@ -115,13 +115,13 @@ Then(
 );
 
 Then(/the response should be of type (.*)/, (type) => {
-  assert.equal(apiResponse.constructor.name, type);
+  assert.equal(apiResponse.data.constructor.name, type);
 });
 
 Then(
   /the response should have a property ([a-zA-Z]*) with value (.*)/,
   (propName, propValue) => {
-    const value = apiResponse[propName];
+    const value = apiResponse.data[propName];
     const formattedValue =
       value instanceof Date ? value.toISOString() : value.toString();
     assert.equal(formattedValue, propValue);
@@ -129,7 +129,7 @@ Then(
 );
 
 Then(/the response should be an array/, () => {
-  assert.isArray(apiResponse);
+  assert.isArray(apiResponse.data);
 });
 
 Then(/the requested URL should be (.*)/, (url) => {
@@ -141,11 +141,11 @@ Then(/the request should have a body with value (.*)/, (body) => {
 });
 
 Then(/the response should be equal to "(.*)"/, (value) => {
-  assert.equal(apiResponse, value);
+  assert.equal(apiResponse.data, value);
 });
 
 Then(/the response should be null/, () => {
-  assert.isNull(apiResponse);
+  assert.isNull(apiResponse.data);
 });
 
 Then(/it should generate a model object named (\w*)/, (modelName) => {

--- a/features/support/support.js
+++ b/features/support/support.js
@@ -62,7 +62,7 @@ When(
 );
 
 When(
-  /calling the method ([a-zA-Z]*) and the server responds with/,
+  /calling the method ([a-zA-Z]*) and the server responds with$/,
   async (methodName, response) => {
     mock.serverResponseObject = JSON.parse(response);
     apiResponse = await api[methodName]();
@@ -95,6 +95,22 @@ When(
 When("selecting the server at index {int}", (index) => {
   api = createApi(index);
 });
+
+When(
+  /calling the method ([a-zA-Z]*) and the server responds with headers$/,
+  async (methodName, headers) => {
+    mock.serverResponseObject = {};
+    mock.serverResponseHeaders = JSON.parse(headers);
+    apiResponse = await api[methodName]();
+  }
+);
+
+Then(
+  /the response should have a header (.*) with value (.*)/,
+  (prop, value) => {
+    assert.equal(apiResponse.headers[prop], value);
+  }
+);
 
 Then(/the request method should be of type (.*)/, (type) => {
   assert.equal(mock.requestParams.method, type);

--- a/features/support/util.js
+++ b/features/support/util.js
@@ -20,6 +20,7 @@ async function generateApi(schema) {
 
 let mock = {
   serverResponse: undefined,
+  serverResponseHeaders: undefined,
 };
 
 function createApi(serverIndex = 0) {
@@ -29,7 +30,8 @@ function createApi(serverIndex = 0) {
     const mockTransport = async (params) => {
       mock.requestParams = params;
       return {
-        data: mock.serverResponseObject
+        data: mock.serverResponseObject,
+        headers: mock.serverResponseHeaders,
       };
     };
 

--- a/features/support/util.js
+++ b/features/support/util.js
@@ -28,7 +28,9 @@ function createApi(serverIndex = 0) {
     const Configuration = require("../api/configuration.js");
     const mockTransport = async (params) => {
       mock.requestParams = params;
-      return mock.serverResponseObject;
+      return {
+        data: mock.serverResponseObject
+      };
     };
 
     const config = new Configuration(mockTransport);

--- a/template/api.js.handlebars
+++ b/template/api.js.handlebars
@@ -57,9 +57,14 @@ class Api{{_tag.name}} {
 
         const response = await request(this.config, "{{@root.path}}", "{{@key}}", builder.parameters);
         {{#if _response.schema}}
-        return deserialize(response, "{{typeConvert _response.schema}}");
+        return {
+          ...response,
+          data: deserialize(response.data, "{{typeConvert _response.schema}}")
+        }
         {{else}}
-        return null;
+        return {
+          ...response
+        };
         {{/if}}
       };
 

--- a/template/fetch.js.handlebars
+++ b/template/fetch.js.handlebars
@@ -1,9 +1,19 @@
 async function transport(params) {
-  const response = await fetch(params.url, params);
-  if (response.status !== 200) {
-    throw new Error(`${response.status} ${response.statusText}`);
+  const fetchResponse = await fetch(params.url, params);
+
+  if (fetchResponse.ok) {
+    const json = await fetchResponse.json();
+    return {
+      data: json,
+      statusCode: fetchResponse.status,
+      headers: fetchResponse.headers,
+      type: fetchResponse.type,
+    };
+  } else {
+    throw new Error(
+      `Error ${fetchResponse.status}: ${fetchResponse.statusText}`
+    );
   }
-  return await response.json();
 }
 
 {{{export}}} transport;


### PR DESCRIPTION
Partially implements https://github.com/ScottLogic/openapi-forge/issues/77 by exposing response headers, but does not apply the type information that may be present in the schema